### PR TITLE
Add Vitest and tests for blockchain utils

### DIFF
--- a/lib/blockchain.test.ts
+++ b/lib/blockchain.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { decodeTokenCreationData, determineTransactionType } from './blockchain'
+import { encodeAbiParameters } from 'viem'
+
+// Helper to build transaction input
+function buildInput(methodId: string, params: any[], types: {name:string,type:string}[]) {
+  const encoded = encodeAbiParameters(types, params)
+  return methodId + encoded.slice(2)
+}
+
+describe('decodeTokenCreationData', () => {
+  it('decodes original token creation format', () => {
+    const methodId = '0x0b8c6fec'
+    const types = [
+      { name: 'name', type: 'string' },
+      { name: 'symbol', type: 'string' },
+      { name: 'totalSupply', type: 'uint256' },
+      { name: 'taxPercentage', type: 'uint256' },
+    ]
+    const params = ['My Token', 'MYT', 1000n, 10n]
+    const input = buildInput(methodId, params, types)
+    const result = decodeTokenCreationData(methodId, input)
+    expect(result).toEqual({ name: 'My Token', symbol: 'MYT', totalSupply: '1000' })
+  })
+
+  it('decodes new token creation format', () => {
+    const methodId = '0x30f51a46'
+    const types = [
+      { name: 'param1', type: 'uint16' },
+      { name: 'param2', type: 'uint8' },
+      { name: 'param3', type: 'uint128' },
+      { name: 'param4', type: 'uint8' },
+      { name: 'creator', type: 'address' },
+      { name: 'param6', type: 'uint256' },
+      { name: 'name', type: 'string' },
+      { name: 'symbol', type: 'string' },
+      { name: 'totalSupply', type: 'uint256' },
+    ]
+    const params = [1n, 2n, 3n, 4n, '0x1111111111111111111111111111111111111111', 5n, 'New Token', 'NTK', 5000n]
+    const input = buildInput(methodId, params, types)
+    const result = decodeTokenCreationData(methodId, input)
+    expect(result).toEqual({ name: 'New Token', symbol: 'NTK', totalSupply: '5000', creator: '0x1111111111111111111111111111111111111111' })
+  })
+
+  it('returns null for unknown method', () => {
+    const result = decodeTokenCreationData('0xdeadbeef', '0x')
+    expect(result).toBeNull()
+  })
+})
+
+describe('determineTransactionType', () => {
+  it('uses known signature', () => {
+    const res = determineTransactionType('0xa6f2ae3a', '0')
+    expect(res).toEqual({ type: 'BUY', description: 'Buy tokens with AVAX', method: 'buy' })
+  })
+
+  it('detects create/token keywords', () => {
+    const res = determineTransactionType('0xdeadcreate', '0')
+    expect(res).toEqual({ type: 'TOKEN_CREATION', description: 'Possible token creation', method: 'unknown_create' })
+  })
+
+  it('detects value transfer as buy', () => {
+    const res = determineTransactionType('0xabcdef01', '1000000000000000000') // 1 AVAX
+    expect(res).toEqual({ type: 'BUY', description: 'Buy transaction (AVAX sent)', method: 'unknown_buy' })
+  })
+
+  it('returns unknown otherwise', () => {
+    const res = determineTransactionType('0xabcdef01', '0')
+    expect(res).toEqual({ type: 'UNKNOWN', description: 'Unknown transaction type', method: '0xabcdef01' })
+  })
+})

--- a/lib/blockchain.ts
+++ b/lib/blockchain.ts
@@ -247,7 +247,7 @@ async function fetchCreatorProfile(address: string): Promise<CreatorProfile> {
 }
 
 // Functie om transactie type te bepalen op basis van method ID en value
-function determineTransactionType(
+export function determineTransactionType(
   methodId: string,
   value: string,
 ): {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -67,6 +68,7 @@
     "@types/react-dom": "^19",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.0.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary
- setup Vitest test runner
- export `determineTransactionType` for testing
- add unit tests for `decodeTokenCreationData` and `determineTransactionType`
- add `npm test` script

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2cc5d9f08321852950e2079a37e4