### PR TITLE
Refactor Creators Dashboard to use shared Supabase client

### DIFF
--- a/components/creators-dashboard.tsx
+++ b/components/creators-dashboard.tsx
@@ -5,12 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
-import { createClient } from "@supabase/supabase-js"
-
-// Initialize Supabase client
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ""
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ""
-const supabase = createClient(supabaseUrl, supabaseAnonKey)
+import { supabase } from "@/lib/supabase"
 
 type Creator = {
   wallet_address: string


### PR DESCRIPTION
## Summary
- import the singleton Supabase client
- remove redundant environment variable setup

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2cc19f6c83218235cbb512016e0a